### PR TITLE
Jpuerto/watching param

### DIFF
--- a/appyter/context.py
+++ b/appyter/context.py
@@ -219,6 +219,9 @@ def get_env_from_kwargs(**kwargs):
     if 'hints' in kwargs or 'HINTS' not in _config:
       _config['HINTS'] = try_json_loads(kwargs.get('hints', os.environ.get('APPYTER_HINTS', '')))
   #
+  if 'watch' in kwargs or 'WATCH' not in _config:
+    _config['WATCH'] = False if not _config.get('DEBUG', False) else try_json_loads(kwargs.get('watch', True))
+  #
   if _config['MODE'] == 'default' and (_config['IPYNB'] is None or not os.path.isfile(os.path.join(_config['CWD'], _config['IPYNB']))):
     logger.error('ipynb was not found')
   #

--- a/appyter/render/flask_app/__init__.py
+++ b/appyter/render/flask_app/__init__.py
@@ -132,7 +132,7 @@ def create_app(**kwargs):
 @click_option_setenv('--secret-key', envvar='APPYTER_SECRET_KEY', default=None, help='A secret key for flask')
 @click_option_setenv('--debug', envvar='APPYTER_DEBUG', type=bool, default=True, help='Whether or not we should be in debugging mode, not for use in multi-tenant situations')
 @click_option_setenv('--static-dir', envvar='APPYTER_STATIC_DIR', default='static', help='The folder whether staticfiles are located')
-@click_option_setenv('--watch', envvar='APPYTER_WATCH', type=bool, default=False, help='Whether to watch files or not (when running in development)')
+@click_option_setenv('--watch', envvar='APPYTER_WATCH', type=bool, default=True, help='Whether to watch files or not (when running in development)')
 @click_argument_setenv('ipynb', envvar='APPYTER_IPYNB')
 def flask_app(**kwargs):
   import sys

--- a/appyter/render/flask_app/__init__.py
+++ b/appyter/render/flask_app/__init__.py
@@ -132,6 +132,7 @@ def create_app(**kwargs):
 @click_option_setenv('--secret-key', envvar='APPYTER_SECRET_KEY', default=None, help='A secret key for flask')
 @click_option_setenv('--debug', envvar='APPYTER_DEBUG', type=bool, default=True, help='Whether or not we should be in debugging mode, not for use in multi-tenant situations')
 @click_option_setenv('--static-dir', envvar='APPYTER_STATIC_DIR', default='static', help='The folder whether staticfiles are located')
+@click_option_setenv('--watch', envvar='APPYTER_WATCH', type=bool, default=False, help='Whether to watch files or not (when running in development)')
 @click_argument_setenv('ipynb', envvar='APPYTER_IPYNB')
 def flask_app(**kwargs):
   import sys

--- a/appyter/render/flask_app/development.py
+++ b/appyter/render/flask_app/development.py
@@ -81,7 +81,7 @@ async def serve(app_path, **kwargs):
   # run the app and reload it when necessary
   tasks.append(asyncio.create_task(app_runner(emitter, config)))
   # the underlying appyter library
-  if config['WATCH']:
+  if config.get('WATCH'):
     tasks.append(asyncio.create_task(
       file_watcher(emitter, 'reload', appyter.__path__[0],
         watcher_cls=GlobWatcher,

--- a/appyter/render/flask_app/development.py
+++ b/appyter/render/flask_app/development.py
@@ -75,7 +75,9 @@ async def serve(app_path, **kwargs):
   from appyter.ext.asyncio.event_emitter import EventEmitter
   from appyter.ext.watchgod.watcher import GlobWatcher
   from appyter.context import get_env
+  logger.info(kwargs)
   config = get_env(**kwargs)
+  logger.info(config)
   emitter = EventEmitter()
   tasks = []
   # run the app and reload it when necessary

--- a/appyter/render/flask_app/development.py
+++ b/appyter/render/flask_app/development.py
@@ -81,53 +81,54 @@ async def serve(app_path, **kwargs):
   # run the app and reload it when necessary
   tasks.append(asyncio.create_task(app_runner(emitter, config)))
   # the underlying appyter library
-  tasks.append(asyncio.create_task(
-    file_watcher(emitter, 'reload', appyter.__path__[0],
-      watcher_cls=GlobWatcher,
-      watcher_kwargs=dict(
-        include_dir_glob=['*'],
-        include_file_glob=['*.py'],
-        exclude_dir_glob=[],
-        exclude_file_glob=[],
-      ),
-    )
-  ))
-  # the underlying appyter library's templates/ipynb/staticfiles/...
-  tasks.append(asyncio.create_task(
-    file_watcher(emitter, 'livereload', appyter.__path__[0],
-      watcher_cls=GlobWatcher,
-      watcher_kwargs=dict(
-        include_dir_glob=['*'],
-        include_file_glob=['*'],
-        exclude_dir_glob=[],
-        exclude_file_glob=['*.py'],
-      ),
-    )
-  ))
-  # the appyter itself's filters/blueprints
-  tasks.append(asyncio.create_task(
-    file_watcher(emitter, 'reload', config['CWD'],
-      watcher_cls=GlobWatcher,
-      watcher_kwargs=dict(
-        include_dir_glob=['filters', 'blueprints'],
-        include_file_glob=['*.py'],
-        exclude_dir_glob=[],
-        exclude_file_glob=[],
-      ),
-    )
-  ))
-  # the appyter itself's templates/ipynb/staticfiles/...
-  tasks.append(asyncio.create_task(
-    file_watcher(emitter, 'livereload', config['CWD'],
-      watcher_cls=GlobWatcher,
-      watcher_kwargs=dict(
-        include_dir_glob=['*'],
-        include_file_glob=['*'],
-        exclude_dir_glob=[config['DATA_DIR']],
-        exclude_file_glob=['*.py'],
-      ),
-    )
-  ))
+  if config['WATCH']:
+    tasks.append(asyncio.create_task(
+      file_watcher(emitter, 'reload', appyter.__path__[0],
+        watcher_cls=GlobWatcher,
+        watcher_kwargs=dict(
+          include_dir_glob=['*'],
+          include_file_glob=['*.py'],
+          exclude_dir_glob=[],
+          exclude_file_glob=[],
+        ),
+      )
+    ))
+    # the underlying appyter library's templates/ipynb/staticfiles/...
+    tasks.append(asyncio.create_task(
+      file_watcher(emitter, 'livereload', appyter.__path__[0],
+        watcher_cls=GlobWatcher,
+        watcher_kwargs=dict(
+          include_dir_glob=['*'],
+          include_file_glob=['*'],
+          exclude_dir_glob=[],
+          exclude_file_glob=['*.py'],
+        ),
+      )
+    ))
+    # the appyter itself's filters/blueprints
+    tasks.append(asyncio.create_task(
+      file_watcher(emitter, 'reload', config['CWD'],
+        watcher_cls=GlobWatcher,
+        watcher_kwargs=dict(
+          include_dir_glob=['filters', 'blueprints'],
+          include_file_glob=['*.py'],
+          exclude_dir_glob=[],
+          exclude_file_glob=[],
+        ),
+      )
+    ))
+    # the appyter itself's templates/ipynb/staticfiles/...
+    tasks.append(asyncio.create_task(
+      file_watcher(emitter, 'livereload', config['CWD'],
+        watcher_cls=GlobWatcher,
+        watcher_kwargs=dict(
+          include_dir_glob=['*'],
+          include_file_glob=['*'],
+          exclude_dir_glob=[config['DATA_DIR']],
+          exclude_file_glob=['*.py'],
+        ),
+      )
+    ))
   tasks.append(asyncio.create_task(app_messager(emitter, config)))
   exit_code = 0
   try:

--- a/appyter/render/flask_app/development.py
+++ b/appyter/render/flask_app/development.py
@@ -83,7 +83,9 @@ async def serve(app_path, **kwargs):
   # run the app and reload it when necessary
   tasks.append(asyncio.create_task(app_runner(emitter, config)))
   # the underlying appyter library
-  if config.get('WATCH'):
+  logger.info(config.get('WATCH'))
+  logger.info(config['WATCH'])
+  if config['WATCH']:
     tasks.append(asyncio.create_task(
       file_watcher(emitter, 'reload', appyter.__path__[0],
         watcher_cls=GlobWatcher,

--- a/appyter/render/flask_app/development.py
+++ b/appyter/render/flask_app/development.py
@@ -82,7 +82,6 @@ async def serve(app_path, **kwargs):
   tasks.append(asyncio.create_task(app_runner(emitter, config)))
   # the underlying appyter library
   if config['WATCH']:
-    logger.info('in here')
     tasks.append(asyncio.create_task(
       file_watcher(emitter, 'reload', appyter.__path__[0],
         watcher_cls=GlobWatcher,

--- a/appyter/render/flask_app/development.py
+++ b/appyter/render/flask_app/development.py
@@ -75,17 +75,14 @@ async def serve(app_path, **kwargs):
   from appyter.ext.asyncio.event_emitter import EventEmitter
   from appyter.ext.watchgod.watcher import GlobWatcher
   from appyter.context import get_env
-  logger.info(kwargs)
   config = get_env(**kwargs)
-  logger.info(config)
   emitter = EventEmitter()
   tasks = []
   # run the app and reload it when necessary
   tasks.append(asyncio.create_task(app_runner(emitter, config)))
   # the underlying appyter library
-  logger.info(config.get('WATCH'))
-  logger.info(config['WATCH'])
   if config['WATCH']:
+    logger.info('in here')
     tasks.append(asyncio.create_task(
       file_watcher(emitter, 'reload', appyter.__path__[0],
         watcher_cls=GlobWatcher,


### PR DESCRIPTION
This PR attempts to deal with #137 - it adds a variable that can be passed during init that allows a user to control whether they would like files to be watched or not. This does not affect default behavior, if this param is not set, it will default to True.